### PR TITLE
Clarify MySQL only support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # zlog-sql
-MySQL/SQLite logging plugin for ZNC IRC bouncer written in Python 3
+MySQL logging plugin for ZNC IRC bouncer written in Python 3. The current version supports only MySQL databases.
 
 ## Features
-* Supports MySQL, PostgreSQL and SQLite databases.
+* Supports MySQL database only.
 * Asynchronous database writes on separate thread. Guarantees that ZNC won't hang during SQL connection timeout.
 * Automatic table creation (`CREATE TABLE IF NOT EXIST`)
-* Retry after failed inserts. When database server is offline, logs are buffered to memory. They are saved when database is back online, so you won't lose logs during MySQL/PostgreSQL outages. 
+* Retry after failed inserts. When the database server is offline, logs are buffered to memory. They are saved when the database is back online, so you won't lose logs during MySQL outages.
 
 ## Some statistics
 After having this plugin enabled for around 11 months, below are my statistics of MySQL table:
 * Total logs count: more than 4.87 million.
 * Space usage: 386 MB (data 270 MB, index 116 MB)
 
-MySQL gives great compression ratio and is easily searchable. SQLite database doesn't support compression, but it's easier to setup and migrate.
+MySQL gives great compression ratio and is easily searchable.
 
 ## Quick start
 1. Copy `zlog_sql.py` to `~/.znc/modules/zlog_sql.py`.
@@ -28,25 +28,5 @@ For MySQL, set module argument matching following format:
 mysql://username:password@localhost/database_name
 ```
 **Important:** you need [`PyMySQL`](https://github.com/PyMySQL/PyMySQL) pip package for MySQL logging. Install it with `pip3 install PyMySQL` command.
-
-### PostgreSQL
-For PostgreSQL, set module argument matching following format:
-```
-postgres://username:password@localhost/database_name
-```
-**Important:** you need [`psycopg2`](https://github.com/psycopg/psycopg2) pip package for PostgreSQL logging. Install it with `pip3 install psycopg2` command.
-
-
-### SQLite
-For SQLite use following string format:
-```
-sqlite:///home/user/logs.sqlite
-```
-
-or simply leave out the path
-```
-sqlite
-```
-in this case, logs are going to be written to the default path `~/.znc/moddata/zlog_sql/logs.sqlite`.
 
 5. Save changes. SQL table schema is going to be created automatically.


### PR DESCRIPTION
## Summary
- update feature list and intro to mention only MySQL is supported
- drop PostgreSQL and SQLite setup instructions in README

## Testing
- `python3 -m py_compile zlog_sql.py`


------
https://chatgpt.com/codex/tasks/task_e_6868c21b72e08324bea9f25ad4e7e547