### PR TITLE
Instantiate module queues in OnLoad

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -26,9 +26,6 @@ class zlog_sql(znc.Module):
     has_args = True
     args_help_text = 'Connection string in format: mysql://user:pass@host/database_name'
 
-    log_queue = multiprocessing.SimpleQueue()
-    reply_queue = multiprocessing.SimpleQueue()
-    internal_log = None
     hook_debugging = False
 
     def put_irc(self, user, network, window, mtype, target, message):
@@ -53,6 +50,8 @@ class zlog_sql(znc.Module):
         :return: True if the module loaded successfully, else False.
         """
         self.types = {'msg': 'PRIVMSG', 'action': 'ACTION'}
+        self.log_queue = multiprocessing.SimpleQueue()
+        self.reply_queue = multiprocessing.SimpleQueue()
         self.internal_log = InternalLog(self.GetSavePath())
         self.debug_hook()
 


### PR DESCRIPTION
## Summary
- avoid class variables for queues and logs
- create `log_queue`, `reply_queue`, and `internal_log` in `OnLoad`

## Testing
- `python3 -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_6868c2235eb88324b316ea5257af2f44