### PR TITLE
Improve dispatch timer queue handling

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import multiprocessing
+import queue
 import os
 import pprint
 import re
@@ -12,9 +13,20 @@ import znc
 
 class DispatchTimer(znc.Timer):
     def RunJob(self):
-        if not self.queue.empty():
-            line = self.queue.get()
-            self.put_irc(line[1], line[2], line[3], line[4], line[5], line[6])
+        while True:
+            try:
+                line = self.queue.get_nowait()
+            except queue.Empty:
+                break
+            else:
+                self.put_irc(
+                    line[1],
+                    line[2],
+                    line[3],
+                    line[4],
+                    line[5],
+                    line[6],
+                )
 
 
 class zlog_sql(znc.Module):


### PR DESCRIPTION
## Summary
- handle dispatch queue with get_nowait
- dispatch all pending messages when timer fires

## Testing
- `python3 -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_6868c22b34a483249ee6fb009b820085