### PR TITLE
Handle process cleanup

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -58,16 +58,21 @@ class zlog_sql(znc.Module):
 
         try:
             db = self.parse_args(args)
-            multiprocessing.Process(
+            self.processes = []
+
+            worker = multiprocessing.Process(
                 target=DatabaseThread.worker_safe,
                 args=(
                     db,
                     self.log_queue,
                     self.internal_log
                 )
-            ).start()
+            )
+            worker.start()
+            self.processes.append(worker)
+
             self.isDone = multiprocessing.Value('i', 0)
-            multiprocessing.Process(
+            poller = multiprocessing.Process(
                 target=DatabaseThread.poll_safe,
                 args=(
                     db,
@@ -75,7 +80,9 @@ class zlog_sql(znc.Module):
                     self.isDone,
                     self.internal_log
                 )
-            ).start()
+            )
+            poller.start()
+            self.processes.append(poller)
             timer = self.CreateTimer(DispatchTimer, interval=5, cycles=0, description='Message dispatch timer')
             timer.queue = self.reply_queue
             timer.put_irc = self.put_irc
@@ -94,6 +101,8 @@ class zlog_sql(znc.Module):
         # Terminate worker processes.
         self.log_queue.put(None)
         self.isDone.value = 1
+        for proc in getattr(self, 'processes', []):
+            proc.join()
 
     def GetServer(self):
         pServer = self.GetNetwork().GetCurrentServer()


### PR DESCRIPTION
## Summary
- store worker and poller processes on module load
- join the processes during shutdown

## Testing
- `python3 -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_6868c22e2f34832493df2a711b932511