### PR TITLE
Add SQLite database operations with ordered queries

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -647,3 +647,41 @@ class MySQLDatabase(Database):
         sql = 'DELETE FROM inbound WHERE id = {}'.format(iden)
         self.conn.cursor().execute(sql)
         self.conn.commit()
+
+
+class SQLiteDatabase(Database):
+    def connect(self) -> None:
+        import sqlite3
+        self.conn = sqlite3.connect(**self.dsn)
+
+    def ensure_connected(self):
+        pass
+
+    def insert_into(self, row, table="logs"):
+        cols = ', '.join('[{}]'.format(col) for col in row.keys())
+        vals = ', '.join(':{}'.format(col) for col in row.keys())
+        sql = 'INSERT INTO [{}] ({}) VALUES ({})'.format(table, cols, vals)
+        self.conn.cursor().execute(sql, row)
+        self.conn.commit()
+
+    def fetch_from(self):
+        cur = self.conn.cursor()
+        cur.execute('SELECT * FROM inbound ORDER BY id')
+        res = cur.fetchall()
+        self.conn.commit()
+        return res
+
+    def fetch_logs(self):
+        cur = self.conn.cursor()
+        cur.execute('SELECT * FROM logs ORDER BY id')
+        res = cur.fetchall()
+        self.conn.commit()
+        return res
+
+    def del_from(self, iden):
+        self.conn.cursor().execute('DELETE FROM inbound WHERE id = ?', (iden,))
+        self.conn.commit()
+
+    def del_log(self, iden):
+        self.conn.cursor().execute('DELETE FROM logs WHERE id = ?', (iden,))
+        self.conn.commit()


### PR DESCRIPTION
## Summary
- implement a basic `SQLiteDatabase`
- use `ORDER BY id` when fetching rows
- delete rows by `id` for SQLite tables

## Testing
- `python -m py_compile zlog_sql.py`


------
https://chatgpt.com/codex/tasks/task_e_686c850d376c832483fcb433cf15f5b9