### PR TITLE
Fix network retrieval in logging

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -466,7 +466,7 @@ class zlog_sql(znc.Module):
         self.log_queue.put({
             'created_at': datetime.utcnow().isoformat(),
             'user': self.GetUser().GetUserName() if self.GetUser() is not None else None,
-            'network': self.GetNetwork().GetName() if self.GetUser() is not None else None,
+            'network': self.GetNetwork().GetName() if self.GetNetwork() is not None else None,
             'window': window,
             'type': mtype,
             'nick': nick,


### PR DESCRIPTION
## Summary
- ensure put_log checks GetNetwork() when adding logs

## Testing
- `python -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_686c8f5d1c9483248fa876d6c4b7ae84