### PR TITLE
Cast row to dict in sync_worker

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -663,7 +663,7 @@ class DatabaseThread:
                 rows = local_db.fetch_logs()
                 if rows:
                     for row in rows:
-                        remote_db.insert_into(row, 'logs')
+                        remote_db.insert_into(dict(row), 'logs')
                         local_db.del_log(row['id'])
             except Exception as e:
                 sleep_for = 10


### PR DESCRIPTION
## Summary
- ensure rows are converted to dict before sending to remote DB

## Testing
- `python3 -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_686c8f5f25a08324aceebb5adc08cc80