### PR TITLE
Remove unused format calls

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -572,7 +572,7 @@ class DatabaseThread:
                 sleep(sleep_for)
 
                 with internal_log.error() as target:
-                    target.write('Retrying now.\n'.format(sleep_for))
+                    target.write('Retrying now.\n')
                     log_queue.put(item)
 
     @staticmethod
@@ -625,7 +625,7 @@ class DatabaseThread:
                 sleep(sleep_for)
 
                 with internal_log.error() as target:
-                    target.write('Retrying now.\n'.format(sleep_for))
+                    target.write('Retrying now.\n')
 
     @staticmethod
     def sync_safe(
@@ -679,7 +679,7 @@ class DatabaseThread:
                 sleep(sleep_for)
 
                 with internal_log.error() as target:
-                    target.write('Retrying now.\n'.format(sleep_for))
+                    target.write('Retrying now.\n')
 
 
 class InternalLog:


### PR DESCRIPTION
## Summary
- clean up internal logs in zlog_sql

## Testing
- `python -m py_compile zlog_sql.py`

------
https://chatgpt.com/codex/tasks/task_e_686c8f6122f883249ef43ab76993cc63