### PR TITLE
Fix MySQL deletion query

### DIFF
--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -731,8 +731,8 @@ class MySQLDatabase(Database):
         return res
 
     def del_from(self, iden):
-        sql = 'DELETE FROM inbound WHERE id = {}'.format(iden)
-        self.conn.cursor().execute(sql)
+        sql = 'DELETE FROM inbound WHERE id = %s'
+        self.conn.cursor().execute(sql, (iden,))
         self.conn.commit()
 
 


### PR DESCRIPTION
## Summary
- fix MySQLDatabase.del_from to use parameterized DELETE statement

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686c92afd1dc8324bb9bc3b952c8dc86