### PR TITLE
Add automatic SQLite buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 MySQL logging plugin for ZNC IRC bouncer written in Python 3. It now supports logging to a local SQLite (libSQL) database which can be synced to MySQL/PlanetScale.
 
 ## Features
-* Supports MySQL or a local SQLite buffer.
+* Supports MySQL with an automatic local SQLite buffer or standalone SQLite.
 * Asynchronous database writes on separate thread. Guarantees that ZNC won't hang during SQL connection timeout.
 * Automatic table creation (`CREATE TABLE IF NOT EXISTS`)
 * Retry after failed inserts. When the database server is offline, logs are buffered to memory. They are saved when the database is back online, so you won't lose logs during MySQL outages.
@@ -54,11 +54,14 @@ pip install PyMySQL
 ```
 
 ### SQLite buffer
-To log locally and automatically sync every 5 seconds, use a connection string like:
+When you specify a MySQL connection string the module will automatically create a
+local buffer file named `buffer.db` inside the module's data directory and sync it
+to MySQL every 5 seconds.
+If you want to override the buffer location, use a connection string like:
 ```
 sqlite:///path/to/local.db;mysql://user:pass@host/db
 ```
-The module will spawn a subprocess that pushes buffered rows from the local SQLite
-file to the remote MySQL instance on a 5 second interval.
+The module spawns a subprocess that pushes buffered rows from the local SQLite file
+to the remote MySQL instance on a 5 second interval.
 
 5. Save changes. SQL table schema is going to be created automatically.

--- a/zlog_sql.py
+++ b/zlog_sql.py
@@ -39,7 +39,7 @@ class zlog_sql(znc.Module):
     args_help_text = (
         'Connection string in format: '\
         'mysql://user:pass@host/database_name or '
-        'sqlite:///local.db;mysql://user:pass@host/db'
+        'sqlite:///local.db;mysql://user:pass@host/db (SQLite path optional)'
     )
 
     hook_debugging = False
@@ -512,10 +512,15 @@ class zlog_sql(znc.Module):
 
         match = re.search('^\s*mysql://(.+?):(.+?)@(.+?)/(.+)\s*$', args)
         if match:
-            return MySQLDatabase({'host': match.group(3),
-                                  'user': match.group(1),
-                                  'passwd': match.group(2),
-                                  'db': match.group(4)})
+            buffer_path = os.path.join(self.GetSavePath(), 'buffer.db')
+            local = SQLiteDatabase({'path': buffer_path})
+            remote = MySQLDatabase({
+                'host': match.group(3),
+                'user': match.group(1),
+                'passwd': match.group(2),
+                'db': match.group(4)
+            })
+            return local, remote
 
         match = re.search('^\s*sqlite:///(.+)\s*$', args)
         if match:


### PR DESCRIPTION
## Summary
- update help text for optional SQLite path
- automatically create and use a local SQLite buffer when only a MySQL connection string is given
- document new behavior in README

## Testing
- `python -m py_compile zlog_sql.py`


------
https://chatgpt.com/codex/tasks/task_e_686c95548cb083249aad14122499ef43